### PR TITLE
Fix docker image support ARMv7

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -378,7 +378,7 @@ services:
 
     ### Docker-in-Docker ################################################
     docker-in-docker:
-        image: docker:19.03-dind
+        image: docker:stable
         environment:
             DOCKER_TLS_SAN: DNS:docker-in-docker
         privileged: true


### PR DESCRIPTION
docker-in-docker 19.03-dind version not support  ARMv7
https://hub.docker.com/layers/docker/library/docker/19.03-dind/images/sha256-81f35202223dcd33991fcb0e12d287f854dfb63b0b47e0c805ed87c0dfc4c9b3?context=explore

Change to the latest support stable version
https://hub.docker.com/layers/docker/library/docker/stable/images/sha256-ce46ea18798c578f8923e0ced4c9996c30363fc35edd1b1c40e5e542407818ac?context=explore